### PR TITLE
Add Excel-like selection statistics

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,4 @@ data/**
 webpack.config.json
 node_modules
 team-extension.log
+tests/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+Added Excel-like automatic statistics for the current CSV or XLSX selection: average, non-empty count, numeric count, sample standard deviation, minimum, maximum, and sum.
+
 ## 4.2.66 (June 4, 2026)
 Updated README with new content and updated plugin name.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Powered by [Wijmo](https://developer.mescius.com/wijmo), this extension provides custom editors and previews for CSV files and XLSX spreadsheets in Visual Studio Code and [Visual Studio Code for the Web](https://code.visualstudio.com/docs/editor/vscode-web).
 
+The viewer includes an Excel-like status bar that automatically shows the average, non-empty count, numeric count, sample standard deviation (`STDEV.S`), minimum, maximum, and sum for the current selection in both CSV and XLSX views.
+
 > **Version 4.2.58 fixes many CSV editing issues that occurred in files containing multiline cells.**
 
 Version 4.2 now supports first-class **custom editors** that implement operations such as save, undo, redo, and hot exit. For XLSX files, this is the default, and clicking the name of an XLSX file in explorer view opens the custom editor directly. For CSV files, this is optional, and executing the `Open With` command on the context menu prompts for the built-in or custom editor to be opened. The `Open Preview` command is still supported for both file types.

--- a/out/csv.js
+++ b/out/csv.js
@@ -17,6 +17,7 @@ function initPage() {
     });
 
     var filter = new wijmo.grid.filter.FlexGridFilter(flex);
+    var updateSelectionStatistics = SelectionStatistics.bind(flex, "selectionStatistics");
 
     function getState() {
         var state = {
@@ -107,6 +108,7 @@ function initPage() {
         }
         autoSizeVisibleRows(flex, true);
         preserveState();
+        updateSelectionStatistics();
         if (flex.collectionView) {
             flex.collectionView.collectionChanged.addHandler(() => {
                 preserveState();
@@ -210,6 +212,7 @@ function initPage() {
 
     flex.cellEditEnded.addHandler(function(s, e) {
         cellEditEnded(s, e);
+        updateSelectionStatistics();
     });
 
     flex.pastedCell.addHandler(function(s, e) {
@@ -385,17 +388,17 @@ function resizeGrid() {
     const options = getOptions();
     var div = wijmo.getElement("#flex");
     var bubble = document.getElementById("aboutWjmo");
-    var heightOffset = 25;
+    var statusBar = document.getElementById("viewerStatusBar");
     if(bubble){
         bubble.style.display='';
     }
     if(options.showInfo == null || options.showInfo == false)
     {
-        heightOffset = 0;
         if(bubble){
             bubble.style.display='none';
         }
     }
+    var heightOffset = statusBar ? statusBar.offsetHeight : 28;
     div.style.height = (window.innerHeight - heightOffset).toString() + "px";
 }
 

--- a/out/excel.js
+++ b/out/excel.js
@@ -7,6 +7,7 @@ function initPage() {
 
     var sheet = new wijmo.grid.sheet.FlexSheet("#sheet");
     wijmo.setCss(sheet.hostElement, { "font-family": "" });
+    var updateSelectionStatistics = SelectionStatistics.bind(sheet, "selectionStatistics");
 
     function getState() {
         var sorts = [];
@@ -102,6 +103,7 @@ function initPage() {
         sheet.selectedSheetChanged.addHandler(() => {
             preserveState();
             sheet.autoSizeColumn(0, true);
+            updateSelectionStatistics();
         });
 
         sheet.sortManager.sortDescriptions.collectionChanged.addHandler(() => {
@@ -138,6 +140,7 @@ function initPage() {
                 changed: true,
                 reason: "Cell Edited"
             });
+            updateSelectionStatistics();
         });
     });
     
@@ -148,17 +151,17 @@ function resizeSheet() {
     const options = getOptions();
     var div = wijmo.getElement("#sheet");
     var bubble = document.getElementById("aboutWjmo");
-    var heightOffset = 25;
+    var statusBar = document.getElementById("viewerStatusBar");
     if(bubble){
         bubble.style.display='';
     }
     if(options.showInfo == null || options.showInfo == false)
     {
-        heightOffset = 0;
         if(bubble){
             bubble.style.display='none';
         }
     }
+    var heightOffset = statusBar ? statusBar.offsetHeight : 28;
     div.style.height = (window.innerHeight - heightOffset).toString() + "px";
 }
 

--- a/out/selection-statistics.js
+++ b/out/selection-statistics.js
@@ -1,0 +1,194 @@
+(function (root, factory) {
+    var api = factory();
+    if (typeof module === "object" && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.SelectionStatistics = api;
+    }
+})(typeof self !== "undefined" ? self : this, function () {
+    "use strict";
+
+    function collectionItems(collection) {
+        if (!collection) {
+            return [];
+        }
+        if (Array.isArray(collection)) {
+            return collection;
+        }
+        if (Array.isArray(collection.items)) {
+            return collection.items;
+        }
+        var items = [];
+        for (var i = 0; i < collection.length; i++) {
+            items.push(collection[i]);
+        }
+        return items;
+    }
+
+    function selectedRanges(grid) {
+        var ranges = collectionItems(grid.selectionRanges);
+        if (!ranges.length) {
+            ranges = collectionItems(grid.selectedRanges);
+        }
+        if (!ranges.length && grid.selection) {
+            ranges = [grid.selection];
+        }
+        return ranges.filter(function (range) {
+            return range && range.row != null && range.col != null;
+        });
+    }
+
+    function isNonEmpty(value) {
+        return value !== null && value !== undefined && value !== "";
+    }
+
+    function calculate(values) {
+        var count = 0;
+        var numericCount = 0;
+        var sum = 0;
+        var compensation = 0;
+        var min = null;
+        var max = null;
+        var runningMean = 0;
+        var squaredDeviationSum = 0;
+
+        values.forEach(function (value) {
+            if (!isNonEmpty(value)) {
+                return;
+            }
+            count++;
+            if (typeof value !== "number" || !Number.isFinite(value)) {
+                return;
+            }
+
+            numericCount++;
+            var delta = value - runningMean;
+            runningMean += delta / numericCount;
+            squaredDeviationSum += delta * (value - runningMean);
+            var adjusted = value - compensation;
+            var next = sum + adjusted;
+            compensation = (next - sum) - adjusted;
+            sum = next;
+            min = min === null ? value : Math.min(min, value);
+            max = max === null ? value : Math.max(max, value);
+        });
+
+        if (Object.is(sum, -0)) {
+            sum = 0;
+        }
+        return {
+            count: count,
+            numericCount: numericCount,
+            sum: numericCount ? sum : null,
+            average: numericCount ? sum / numericCount : null,
+            standardDeviation: numericCount > 1
+                ? Math.sqrt(Math.max(0, squaredDeviationSum) / (numericCount - 1))
+                : null,
+            min: min,
+            max: max
+        };
+    }
+
+    function calculateGridSelection(grid) {
+        var values = [];
+        var visited = Object.create(null);
+        selectedRanges(grid).forEach(function (range) {
+            var top = Math.min(range.row, range.row2 == null ? range.row : range.row2);
+            var bottom = Math.max(range.row, range.row2 == null ? range.row : range.row2);
+            var left = Math.min(range.col, range.col2 == null ? range.col : range.col2);
+            var right = Math.max(range.col, range.col2 == null ? range.col : range.col2);
+
+            top = Math.max(0, top);
+            left = Math.max(0, left);
+            bottom = Math.min(grid.rows.length - 1, bottom);
+            right = Math.min(grid.columns.length - 1, right);
+
+            for (var row = top; row <= bottom; row++) {
+                for (var col = left; col <= right; col++) {
+                    var key = row + ":" + col;
+                    if (!visited[key]) {
+                        visited[key] = true;
+                        values.push(grid.getCellData(row, col, false));
+                    }
+                }
+            }
+        });
+        return calculate(values);
+    }
+
+    var numberFormatter = typeof Intl !== "undefined"
+        ? new Intl.NumberFormat(undefined, { maximumFractionDigits: 10 })
+        : null;
+
+    function formatNumber(value) {
+        if (value === null || value === undefined || !Number.isFinite(value)) {
+            return "—";
+        }
+        return numberFormatter ? numberFormatter.format(value) : String(value);
+    }
+
+    function render(stats, element) {
+        if (!element) {
+            return;
+        }
+        var fields = {
+            average: formatNumber(stats.average),
+            count: String(stats.count),
+            numericCount: String(stats.numericCount),
+            standardDeviation: formatNumber(stats.standardDeviation),
+            min: formatNumber(stats.min),
+            max: formatNumber(stats.max),
+            sum: formatNumber(stats.sum)
+        };
+        Object.keys(fields).forEach(function (name) {
+            var target = element.querySelector('[data-stat-value="' + name + '"]');
+            if (target) {
+                target.textContent = fields[name];
+            }
+        });
+        element.classList.toggle("has-numeric-selection", stats.numericCount > 0);
+    }
+
+    function bind(grid, elementId) {
+        var frame = null;
+        var update = function () {
+            if (frame !== null && typeof cancelAnimationFrame === "function") {
+                cancelAnimationFrame(frame);
+            }
+            var run = function () {
+                frame = null;
+                render(calculateGridSelection(grid), document.getElementById(elementId));
+            };
+            frame = typeof requestAnimationFrame === "function" ? requestAnimationFrame(run) : null;
+            if (frame === null) {
+                run();
+            }
+        };
+        var events = [
+            grid.selectionChanged,
+            grid.itemsSourceChanged,
+            grid.cellEditEnded,
+            grid.selectedSheetChanged
+        ];
+        events.forEach(function (event) {
+            if (event && typeof event.addHandler === "function") {
+                event.addHandler(update);
+            }
+        });
+        [grid.selectionRanges, grid.selectedRanges].forEach(function (ranges) {
+            if (ranges && ranges.collectionChanged && typeof ranges.collectionChanged.addHandler === "function") {
+                ranges.collectionChanged.addHandler(update);
+            }
+        });
+        update();
+        return update;
+    }
+
+    return {
+        calculate: calculate,
+        calculateGridSelection: calculateGridSelection,
+        formatNumber: formatNumber,
+        bind: bind
+    };
+});

--- a/out/styles/vscode.css
+++ b/out/styles/vscode.css
@@ -102,6 +102,53 @@ div[role=gridcell] {
 .wj-sheet-page {
     height: 100%;
 }
+
+/* Excel-like statistics for the current selection. */
+.viewer-statusbar {
+    box-sizing: border-box;
+    position: fixed;
+    z-index: 10000;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    min-height: 28px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 4px 12px;
+    overflow-x: auto;
+    white-space: nowrap;
+    color: var(--vscode-statusBar-foreground, var(--vscode-editor-foreground));
+    background: var(--vscode-statusBar-background, var(--vscode-sideBar-background));
+    border-top: 1px solid var(--vscode-statusBar-border, var(--vscode-tree-indentGuidesStroke));
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+}
+.viewer-statusbar #aboutWjmo {
+    margin-right: auto;
+    opacity: 0.8;
+}
+.viewer-statusbar #aboutWjmo a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+}
+.selection-statistics {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 20px;
+    margin-left: auto;
+}
+.selection-statistics .numeric-stat {
+    display: none;
+}
+.selection-statistics.has-numeric-selection .numeric-stat {
+    display: inline;
+}
+.selection-statistics .stat-value {
+    font-variant-numeric: tabular-nums;
+}
 .wj-flexsheet .wj-tabholder {
     background-color: var(--vscode-sideBar-background);
 }

--- a/src/csvDocumentView.ts
+++ b/src/csvDocumentView.ts
@@ -241,10 +241,22 @@ export default class CsvDocumentView extends BaseDocumentView {
         <script src="${this.scriptUri}/controls/wijmo.input.min.js" type="text/javascript"></script>
         <script src="${this.scriptUri}/controls/wijmo.grid.min.js" type="text/javascript"></script>
         <script src="${this.scriptUri}/controls/wijmo.grid.filter.min.js" type="text/javascript"></script>
+        <script src="${this.scriptUri}/selection-statistics.js"></script>
         <script src="${this.scriptUri}/csv.js"></script>
         <body style="padding:0px; overflow:hidden" onload="resizeGrid()" onresize="resizeGrid()">
             <div id="flex"></div>
-            <div id="aboutWjmo" style="box-sizing: border-box;position:fixed;z-index:10000;bottom:0px;left:0px;right:0px;padding:4px 20px;background: rgb(90,227,255);background: linear-gradient(129deg, rgba(90,227,255,1) 0%, rgba(5,77,107,1) 100%);color:#000;text-align:right;">powered by: <a href="https://developer.mescius.com/wijmo/flexgrid-javascript-data-grid?utm_source=VSCode&utm_medium=Wijmo-Extension" target="_blank" style="color:#fff;text-decoration:none;font-weight:600;">Wijmo FlexGrid</a></div>
+            <div id="viewerStatusBar" class="viewer-statusbar">
+                <div id="aboutWjmo">powered by: <a href="https://developer.mescius.com/wijmo/flexgrid-javascript-data-grid?utm_source=VSCode&utm_medium=Wijmo-Extension" target="_blank">Wijmo FlexGrid</a></div>
+                <div id="selectionStatistics" class="selection-statistics" role="status" aria-live="polite" title="Count includes all non-empty cells; other metrics include numeric cells only">
+                    <span class="numeric-stat">Average: <span class="stat-value" data-stat-value="average">—</span></span>
+                    <span>Count: <span class="stat-value" data-stat-value="count">0</span></span>
+                    <span class="numeric-stat">Numerical Count: <span class="stat-value" data-stat-value="numericCount">0</span></span>
+                    <span class="numeric-stat">Std Dev: <span class="stat-value" data-stat-value="standardDeviation">—</span></span>
+                    <span class="numeric-stat">Min: <span class="stat-value" data-stat-value="min">—</span></span>
+                    <span class="numeric-stat">Max: <span class="stat-value" data-stat-value="max">—</span></span>
+                    <span class="numeric-stat">Sum: <span class="stat-value" data-stat-value="sum">—</span></span>
+                </div>
+            </div>
         </body>
         <script type="text/javascript">
             wijmo.setLicenseKey("${getLicenseKey()}");

--- a/src/excelDocumentView.ts
+++ b/src/excelDocumentView.ts
@@ -87,10 +87,22 @@ export default class ExcelDocumentView extends BaseDocumentView {
         <script src="${this.scriptUri}/controls/wijmo.grid.xlsx.min.js" type="text/javascript"></script>
         <script src="${this.scriptUri}/controls/wijmo.xlsx.min.js" type="text/javascript"></script>
         <script src="${this.scriptUri}/jszip.min.js"></script>
+        <script src="${this.scriptUri}/selection-statistics.js"></script>
         <script src="${this.scriptUri}/excel.js"></script>
         <body style="padding:0px; overflow:hidden" onload="resizeSheet()" onresize="resizeSheet()">
             <div id="sheet"></div>
-            <div id="aboutWjmo" style="box-sizing: border-box;position:fixed;z-index:10000;bottom:0px;left:0px;right:0px;padding:4px 20px;background: rgb(90,227,255);background: linear-gradient(129deg, rgba(90,227,255,1) 0%, rgba(5,77,107,1) 100%);color:#000;text-align:right;">powered by: <a href="https://developer.mescius.com/wijmo/flexgrid-javascript-data-grid?utm_source=VSCode&utm_medium=Wijmo-Extension" target="_blank" style="color:#fff;text-decoration:none;font-weight:600;">Wijmo FlexGrid</a></div>
+            <div id="viewerStatusBar" class="viewer-statusbar">
+                <div id="aboutWjmo">powered by: <a href="https://developer.mescius.com/wijmo/flexgrid-javascript-data-grid?utm_source=VSCode&utm_medium=Wijmo-Extension" target="_blank">Wijmo FlexGrid</a></div>
+                <div id="selectionStatistics" class="selection-statistics" role="status" aria-live="polite" title="Count includes all non-empty cells; other metrics include numeric cells only">
+                    <span class="numeric-stat">Average: <span class="stat-value" data-stat-value="average">—</span></span>
+                    <span>Count: <span class="stat-value" data-stat-value="count">0</span></span>
+                    <span class="numeric-stat">Numerical Count: <span class="stat-value" data-stat-value="numericCount">0</span></span>
+                    <span class="numeric-stat">Std Dev: <span class="stat-value" data-stat-value="standardDeviation">—</span></span>
+                    <span class="numeric-stat">Min: <span class="stat-value" data-stat-value="min">—</span></span>
+                    <span class="numeric-stat">Max: <span class="stat-value" data-stat-value="max">—</span></span>
+                    <span class="numeric-stat">Sum: <span class="stat-value" data-stat-value="sum">—</span></span>
+                </div>
+            </div>
         </body>
         <script type="text/javascript">
             wijmo.setLicenseKey("${getLicenseKey()}");

--- a/tests/selection-statistics.browser.html
+++ b/tests/selection-statistics.browser.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../out/styles/wijmo.min.css">
+</head>
+<body>
+    <div id="flex" style="width: 600px; height: 240px"></div>
+    <div id="sheet" style="width: 600px; height: 240px"></div>
+    <div id="selectionStatistics" class="selection-statistics">
+        <span data-stat-value="average"></span>
+        <span data-stat-value="count"></span>
+        <span data-stat-value="numericCount"></span>
+        <span data-stat-value="standardDeviation"></span>
+        <span data-stat-value="min"></span>
+        <span data-stat-value="max"></span>
+        <span data-stat-value="sum"></span>
+    </div>
+    <div id="sheetSelectionStatistics">
+        <span data-sheet-stat-value="average"></span>
+        <span data-sheet-stat-value="count"></span>
+        <span data-sheet-stat-value="sum"></span>
+    </div>
+    <script src="../out/controls/wijmo.min.js"></script>
+    <script src="../out/controls/wijmo.input.min.js"></script>
+    <script src="../out/controls/wijmo.grid.min.js"></script>
+    <script src="../out/controls/wijmo.grid.filter.min.js"></script>
+    <script src="../out/controls/wijmo.grid.sheet.min.js"></script>
+    <script src="../out/selection-statistics.js"></script>
+    <script>
+        var flex = new wijmo.grid.FlexGrid("#flex", {
+            itemsSource: [
+                { value: "tct_s" },
+                { value: 164.22 },
+                { value: 165.08 },
+                { value: 154.58 }
+            ]
+        });
+        SelectionStatistics.bind(flex, "selectionStatistics");
+        flex.selection = new wijmo.grid.CellRange(0, 0, 3, 0);
+        var sheet = new wijmo.grid.sheet.FlexSheet("#sheet");
+        sheet.addUnboundSheet("Sheet1", 4, 1);
+        ["tct_s", 164.22, 165.08, 154.58].forEach(function (value, row) {
+            sheet.setCellData(row, 0, value);
+        });
+        sheet.selection = new wijmo.grid.CellRange(0, 0, 3, 0);
+        requestAnimationFrame(function () {
+            requestAnimationFrame(function () {
+                var values = {};
+                document.querySelectorAll("[data-stat-value]").forEach(function (item) {
+                    values[item.getAttribute("data-stat-value")] = item.textContent;
+                });
+                document.body.setAttribute("data-selection-statistics", JSON.stringify(values));
+                var sheetStats = SelectionStatistics.calculateGridSelection(sheet);
+                document.body.setAttribute("data-sheet-selection-statistics", JSON.stringify(sheetStats));
+            });
+        });
+    </script>
+</body>
+</html>

--- a/tests/selection-statistics.test.js
+++ b/tests/selection-statistics.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const assert = require("assert");
+const stats = require("../out/selection-statistics");
+
+function test(name, fn) {
+    try {
+        fn();
+        process.stdout.write(`PASS ${name}\n`);
+    } catch (error) {
+        process.stderr.write(`FAIL ${name}\n${error.stack}\n`);
+        process.exitCode = 1;
+    }
+}
+
+test("matches Excel count versus numeric aggregation semantics", () => {
+    const result = stats.calculate([
+        "tct_s",
+        164.22, 165.08, 154.58, 238.77, 204.18, 193.68, 165.1,
+        218.29, 248.56, 301.49, 199.55, 133.68, 172.96, 162.02
+    ]);
+    assert.strictEqual(result.count, 15);
+    assert.strictEqual(result.numericCount, 14);
+    assert.strictEqual(result.sum, 2722.16);
+    assert.strictEqual(result.average, 194.44);
+    assert.ok(Math.abs(result.standardDeviation - 45.12661094503569) < 1e-12);
+    assert.strictEqual(result.min, 133.68);
+    assert.strictEqual(result.max, 301.49);
+});
+
+test("ignores blanks, dates, booleans, NaN, and infinity for numeric metrics", () => {
+    const result = stats.calculate([null, undefined, "", new Date(0), false, NaN, Infinity, -2, 5]);
+    assert.deepStrictEqual(result, {
+        count: 6,
+        numericCount: 2,
+        sum: 3,
+        average: 1.5,
+        standardDeviation: 4.949747468305833,
+        min: -2,
+        max: 5
+    });
+});
+
+test("deduplicates overlapping selection ranges", () => {
+    const grid = {
+        rows: [{}, {}],
+        columns: [{}, {}],
+        selectionRanges: [
+            { row: 0, row2: 1, col: 0, col2: 0 },
+            { row: 1, row2: 1, col: 0, col2: 1 }
+        ],
+        getCellData(row, col) {
+            return [[1, 2], [3, 4]][row][col];
+        }
+    };
+    assert.deepStrictEqual(stats.calculateGridSelection(grid), {
+        count: 3,
+        numericCount: 3,
+        sum: 8,
+        average: 8 / 3,
+        standardDeviation: Math.sqrt(7 / 3),
+        min: 1,
+        max: 4
+    });
+});
+
+test("uses stable summation for common decimal values", () => {
+    const result = stats.calculate([0.1, 0.2, 0.3]);
+    assert.strictEqual(result.sum, 0.6);
+    assert.ok(Math.abs(result.average - 0.2) < 1e-15);
+    assert.strictEqual(stats.formatNumber(result.average), "0.2");
+});
+
+test("shows no sample standard deviation for a single numeric cell", () => {
+    assert.strictEqual(stats.calculate([7]).standardDeviation, null);
+});


### PR DESCRIPTION
## Summary

- add an Excel-like status bar for the current CSV and XLSX selection
- report average, non-empty count, numeric count, sample standard deviation, minimum, maximum, and sum
- handle blanks, dates, booleans, non-finite values, overlapping ranges, and decimal summation consistently

## Why

Reviewing numeric columns currently requires copying data into another spreadsheet just to inspect basic aggregate statistics. This keeps that common workflow inside the viewer and follows Excel's distinction between non-empty and numeric counts.

## Implementation notes

The calculation logic is shared by CSV FlexGrid and XLSX FlexSheet views. The status bar is rendered inside the webview and updates from selection and data-change events.

## Validation

- `node tests/selection-statistics.test.js`
- `npm run compile`
- headless browser smoke test for CSV and XLSX selection updates
- `git diff --check upstream/master..agent/upstream-selection-statistics`

This PR intentionally contains no extension version bump or publisher-specific packaging changes.
